### PR TITLE
Implement Obj Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # VSCode project settings
 /.vscode
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5)
+project(NumericasLibrary)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add source files
+set(SOURCES
+    main.cpp
+    parser/objparser.cpp
+)
+
+# Create executable
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+# Include header directories
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/parser
+)

--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,13 @@
 
+#include "parser/objparser.h"
 #include <iostream>  // Include the I/O stream library
 
 int main() {
     // Print "Hello, World!" to the console
     std::cout << "Hello, World!" << std::endl;
+    ObjParser parser("../../Data/rectangle-prism-final.obj");
+    parser.parseObjFile();
+    parser.printObjFile();
+
     return 0;  // Return 0 to indicate successful execution
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,8 +3,7 @@
 #include <iostream>  // Include the I/O stream library
 
 int main() {
-    // Print "Hello, World!" to the console
-    std::cout << "Hello, World!" << std::endl;
+    
     ObjParser parser("../../Data/rectangle-prism-final.obj");
     parser.parseObjFile();
     parser.printObjFile();

--- a/parser/objparser.cpp
+++ b/parser/objparser.cpp
@@ -1,0 +1,40 @@
+#include "objparser.h"
+#include <sstream>
+#include <fstream>
+#include <iostream>
+
+ObjParser::ObjParser() {}
+
+ObjParser::ObjParser(const std::string fileName)
+    : m_FileName(fileName) {}
+
+void ObjParser::parseObjFile()
+{
+    std::ifstream objFile(m_FileName);
+
+    if(!objFile.is_open()) {
+        std::cout << "Failed to open the OBJ file!" << std::endl;
+        return;
+    }
+
+    std::string line;
+    while(std::getline(objFile, line)) {
+        if (line.substr(0, 2) == "v ") {
+            std::istringstream iss(line.substr(2));
+            Vertex v;
+            iss >> v.x >> v.y >> v.z;
+            m_Vertices.push_back(v);
+        }
+    }
+
+    objFile.close();
+
+}
+
+void ObjParser::printObjFile() {
+    std::cout << "Vertices:\n";
+    for (const auto& v : m_Vertices) {
+        std::cout << "v " << v.x << " " << v.y << " " << v.z << std::endl;;
+    }
+}
+    

--- a/parser/objparser.h
+++ b/parser/objparser.h
@@ -1,0 +1,23 @@
+#include <string>
+#include <vector>
+
+struct Vertex {
+    float x, y, z;
+};
+
+class ObjParser
+{
+    public:
+        ObjParser();
+        ObjParser(const std::string fileName);
+        
+        void parseObjFile();
+        void printObjFile();
+
+        void setFileName(std::string fileName);
+
+        std::vector<Vertex> getVertices();
+    private:
+        std::string m_FileName;
+        std::vector<Vertex> m_Vertices;
+};


### PR DESCRIPTION
Implemented obj parser, currently only vertices are required for triangulation so only vertices are parsed.
The file name is hard code, later the file name or path shall be passed by the GUI from the user, when the library is used within the interface.